### PR TITLE
Fixes and new Features

### DIFF
--- a/dlls/game/api_stef2.cpp
+++ b/dlls/game/api_stef2.cpp
@@ -1025,7 +1025,26 @@ Sentient* gamefixAPI_getOwner(Entity* entity)
 	return nullptr;
 }
 
+//--------------------------------------------------------------
+// GAMEFIX - Added: Function to set last inflictor - chrissstrahl
+//--------------------------------------------------------------
+void gameFixAPI_setLastInflictor(Entity* entity, Entity* eInflictor)
+{
+	if (entity) {
+		gamefix_entity_extraData_t[entity->entnum].lastInflictor = eInflictor;
+	}
+}
 
+//--------------------------------------------------------------
+// GAMEFIX - Added: Function to return last inflictor - chrissstrahl
+//--------------------------------------------------------------
+Entity* gameFixAPI_getLastInflictor(Entity* entity)
+{
+	if (!entity) {
+		return nullptr;
+	}
+	return (Entity*)gamefix_entity_extraData_t[entity->entnum].lastInflictor;
+}
 
 //--------------------------------------------------------------
 // GAMEFIX - Added: Function to handle activation time in Multiplayer - chrissstrahl

--- a/dlls/game/api_stef2.hpp
+++ b/dlls/game/api_stef2.hpp
@@ -79,6 +79,8 @@ void gameFixAPI_levelfix_m11l3a_drull_ruins3_boss();
 void gameFixAPI_levelfix_swsglobe();
 void gameFixAPI_maxLevelitems_ctf_grey();
 void gameFixAPI_spawnlocations_dm_ctf_voy1();
+void gameFixAPI_setLastInflictor(Entity* entity, Entity* eInflictor);
+Entity* gameFixAPI_getLastInflictor(Entity* entity);
 float gameFixAPI_getActivationTime(Entity* entity);
 Player* gameFixAPI_getActivator(Entity* puzzle);
 void gameFixAPI_setActivator(Entity* entity, Entity* activator);

--- a/dlls/game/g_main.cpp
+++ b/dlls/game/g_main.cpp
@@ -2237,6 +2237,17 @@ extern "C" const char *G_ClientConnect( int clientNum, qboolean firstTime, qbool
 				return "$$InvalidPassword$$";
 			}
 		}
+
+
+		//--------------------------------------------------------------
+		// GAMEFIX - Fixed: Crash when any client other than host connects to a listen server after changing sv_maxclients and loading a new map - chrissstrahl
+		// This issue should be looked upon in more detail and possibly fixed in the future,
+		// for now we expect the host to shut down the server and restart with corrected sv_maxclients
+		//--------------------------------------------------------------
+		if (clientNum < 0 || clientNum >= game.maxclients) {
+			return va("game.maxclients (sv_maxclients) is %d, connection rejected", game.maxclients);
+		}
+
 		
 		// they can connect
 		ent->client = game.clients + clientNum;
@@ -2247,6 +2258,14 @@ extern "C" const char *G_ClientConnect( int clientNum, qboolean firstTime, qbool
 		// take it, otherwise spawn one from scratch
 		if ( firstTime && !ent->entity )
 		{
+			//--------------------------------------------------------------
+			// GAMEFIX - Added: Protection, against possible crash, rather shutting game down nicely - chrissstrahl
+			//--------------------------------------------------------------
+			if (!client) {
+				gi.Error(ERR_DROP, "G_ClientConnect: client [%s] was NULL", clientNum);
+			}
+
+
 			memset( client, 0, sizeof( *client ) );
 			
 			// clear the respawning variables

--- a/dlls/game/gamefix.hpp
+++ b/dlls/game/gamefix.hpp
@@ -92,6 +92,7 @@ struct gamefix_entity_extraData_s
 {
 	EntityPtr		activator = nullptr;
 	float			lastActivated = -9999.0f;
+	EntityPtr		lastInflictor = nullptr;
 };
 extern gamefix_entity_extraData_s gamefix_entity_extraData_t[MAX_GENTITIES];
 

--- a/dlls/game/navigate.cpp
+++ b/dlls/game/navigate.cpp
@@ -205,6 +205,11 @@ void PathManager::ResetNodes(	void )
 
 	for( int i = 0; i < PATHMAP_GRIDSIZE; i++ )
 	{
+		//--------------------------------------------------------------
+		// GAMEFIX - Fixed: Crash with Pathnodes when 'reloading' same map on listen server with sv_maxclients latched. - chrissstrahl
+		//--------------------------------------------------------------
+		if (!_mapCells[i]) continue;
+
 		for( int j = 0; j < PATHMAP_GRIDSIZE; j++ )
 		{
 			if ( _mapCells[i][j] )

--- a/dlls/game/player.cpp
+++ b/dlls/game/player.cpp
@@ -3291,9 +3291,6 @@ Player::Player()
 		if ( !LoadingSavegame )
 			SetTargetName( "player" );
 	}
-	else {
-		SetTargetName(va("player%d", client->ps.clientNum));
-	}
 
 	
 	_powerup = NULL;
@@ -3330,6 +3327,14 @@ Player::Player()
 	}
 	
 	Init();
+
+	//--------------------------------------------------------------
+	// GAMEFIX - Added: Players get targetnames with their client-ID attached in multiplayer - chrissstrahl
+	// Needs to be done after Init() or ps.clientNum isn't set yet
+	//--------------------------------------------------------------
+	if (g_gametype->integer != GT_SINGLE_PLAYER) {
+		SetTargetName(va("player%d", client->ps.clientNum));
+	}
 	
 	_viewMode = 0;
 	

--- a/dlls/game/playerheuristics.cpp
+++ b/dlls/game/playerheuristics.cpp
@@ -451,8 +451,16 @@ void PlayerHeuristics::CheckForHeuristicFile()
 	filename = gi.GetArchiveFileName( NULL, s, "log", qtrue );
 	heuristicFileName = filename.c_str();
 	
-	filesize = gi.FS_ReadFile( heuristicFileName.c_str(), NULL, true );
-	if ( filesize <= 0 ) //File Does Not Exsist
+
+	//--------------------------------------------------------------
+	// GAMEFIX - Fixed: Crash, when connecting with a second client from the same base to listen server - chrissstrahl
+	//--------------------------------------------------------------
+	char* buffer = nullptr;
+	filesize = gi.FS_ReadFile(heuristicFileName.c_str(), (void**)&buffer, true);
+	gi.FS_FreeFile(buffer);
+
+
+	if ( filesize <= 0 )
 		CreateInitialHeuristicFile();
 }
 


### PR DESCRIPTION
Moved: targetnameing, all players where names player0
Fixed: Chrash when 'reloading' same map on listen server
Fixed: Crash, when connecting with a second client from the same base…
Added: Last Inflictor Functions
Fixed: Crash on client connect, Added: Possible crash catch