### PR TITLE
Added: CuePlayer to Player::cinematicStopped

### DIFF
--- a/dlls/game/player.cpp
+++ b/dlls/game/player.cpp
@@ -14184,6 +14184,8 @@ void Player::cinematicStopped( void )
 			gamefix_setMakeSolidAsap((Entity*)this, true, 0.0f);
 			showModel();
 		}
+		
+		SetCamera(NULL, 0.0f);
 	}
 }
 


### PR DESCRIPTION
This will make the player view from his own camera again, even if it was forgotten in the scripts to reset it